### PR TITLE
Revert "tick: Cleanup NOHZ per cpu data on cpu down"

### DIFF
--- a/kernel/time/tick-sched.c
+++ b/kernel/time/tick-sched.c
@@ -811,7 +811,7 @@ void tick_cancel_sched_timer(int cpu)
 		hrtimer_cancel(&ts->sched_timer);
 # endif
 
-	memset(ts, 0, sizeof(*ts));
+	ts->nohz_mode = NOHZ_MODE_INACTIVE;
 }
 #endif
 


### PR DESCRIPTION
andip71: This was a bug introduced in upstream to 3.0.79 which impacts CPU frequency scaling

This reverts commit b9cbfd27308999d2ae56d1d341a3a77f91d04a19.

Change-Id: I20aec7487cd7e426d52ce1724ee6216e594ba199
