### PR TITLE
IsoRec: Isolated Recovery for the Exynos 4210 family

### DIFF
--- a/usr/galaxys2_initramfs_files/init
+++ b/usr/galaxys2_initramfs_files/init
@@ -12,8 +12,24 @@ busybox mount -t sysfs sysfs /sys
 load_image=/stage1/boot.cpio
 
 if busybox grep -q bootmode=2 /proc/cmdline ; then
-	# recovery boot
-	load_image=/stage1/recovery.cpio
+
+    # recovery boot
+
+    # default to recovery ramdisk bundled with kernel
+    load_image=/stage1/recovery.cpio
+
+    # attempt isorec (isolated recovery) boot
+
+    # if the raw /dev/block/platform/dw_mmc/by-name/RECOVERY
+    # partition contains valid lzop-compressed data
+    if busybox lzop -dc /dev/block/mmcblk0p6 > /stage1/isorec.cpio ; then
+        # and if said data is a valid cpio archive
+        if busybox cpio -t < /stage1/isorec.cpio ; then
+            # then use it as the recovery ramdisk
+            load_image=/stage1/isorec.cpio
+        fi
+    fi
+
 fi
 
 busybox cpio -i < ${load_image}


### PR DESCRIPTION
IsoRec aims to be a standard by which the monolithic kernel/recovery binaries
of the S2 family of devices can invoke an alternate recovery optionally flashed
separately by the user.

The alternate recovery is flashed to the RECOVERY partition (/dev/block/mmcblk0p6),
a seemingly vestigial partition without any real use. Only the lzop-compressed,
cpio-formatted recovery ramdrive is stored there; the standard kernel image is
used to run this recovery. The lzop-compressed image of the ramdrive is stored
raw in the RECOVERY partition.

Behavior of patch:
-skip all this if not booting into recovery.
-if the raw recovery partition contains valid lzop-compressed data,
-and if said data is a valid cpio archive,
-then use that cpio archive as the recovery ramdrive;
-else use the default recovery ramdrive bundled with the kernel.

More information here:
http://forum.xda-developers.com/galaxy-s2/orig-development/isorec-isolated-recovery-galaxy-s2-t3291176

Change-Id: I2fa1b764b52915262374124ea28f5a2585314891
