### PR TITLE
mali: 3-step gpu DVFS control for Exynos 4210

### DIFF
--- a/drivers/gpu/mali400/r3p2/mali/platform/pegasus-m400/exynos4_pmm.c
+++ b/drivers/gpu/mali400/r3p2/mali/platform/pegasus-m400/exynos4_pmm.c
@@ -38,7 +38,7 @@
 #include <linux/workqueue.h>
 
 #ifdef CONFIG_CPU_EXYNOS4210
-#define MALI_DVFS_STEPS 2
+#define MALI_DVFS_STEPS 3
 #define MALI_DVFS_WATING 10 /* msec */
 #define MALI_DVFS_DEFAULT_STEP 0
 #else
@@ -87,7 +87,11 @@ typedef struct mali_runtime_resumeTag{
 	unsigned int step;
 }mali_runtime_resume_table;
 
-mali_runtime_resume_table mali_runtime_resume = {266, 900000, 1};
+#if defined(CONFIG_CPU_EXYNOS4212) || defined(CONFIG_CPU_EXYNOS4412)
+mali_runtime_resume_table mali_runtime_resume = {266, 900000, 1}; /* step 1 */
+#else
+mali_runtime_resume_table mali_runtime_resume = {160, 950000, 1}; /* step 1 */
+#endif
 
 /* dvfs table */
 mali_dvfs_table mali_dvfs[MALI_DVFS_STEPS]={
@@ -98,8 +102,10 @@ mali_dvfs_table mali_dvfs[MALI_DVFS_STEPS]={
 			/* step 3 */{440  ,1000000	,1025000   ,85   , 90},
 			/* step 4 */{533  ,1000000	,1075000   ,95   ,100} };
 #else
-			/* step 0 */{134  ,1000000	, 950000   ,85   , 90},
-			/* step 1 */{267  ,1000000	,1050000   ,85   ,100} };
+			/* step 0 */{100  ,1000000	, 950000   ,0   , 85},
+			/* step 1 */{160  ,1000000	, 950000   ,80   ,90},
+			/* step 2 */{267  ,1000000	,1000000   ,80   ,100},
+ };
 #endif
 
 #ifdef EXYNOS4_ASV_ENABLED
@@ -166,16 +172,22 @@ static unsigned int asv_3d_volt_4212_9_table[MALI_DVFS_STEPS][ASV_LEVEL_PD] = {
 #else
 
 static unsigned int asv_3d_volt_4210_12_table[MALI_DVFS_STEPS][ASV_LEVEL_4210_12] = {
-	{  1000000,  1000000,  1000000,   950000,   950000,   950000,   950000,   950000},	/* L1(134Mhz) */
+	{  1000000,  1000000,  1000000,   950000,   950000,   950000,   950000,   950000},	/* L2(100Mhz) */
 #if (MALI_DVFS_STEPS > 1)
-	{  1100000,  1100000,  1100000,  1000000,  1000000,  1000000,  1000000,   950000},	/* L0(266Mhz) */
+	{  1000000,  1000000,  1000000,   950000,   950000,   950000,   950000,   950000},	/* L1(160Mhz) */
+#if (MALI_DVFS_STEPS > 2)
+	{  1100000,  1100000,  1100000,  1000000,  1000000,  1000000,  1000000,   950000},	/* L0(267Mhz) */
+#endif
 #endif
 };
 
 static unsigned int asv_3d_volt_4210_14_table[MALI_DVFS_STEPS][ASV_LEVEL_4210_14] = {
-	{  1000000,  1000000,   950000,   950000,   950000},	/* L1(134Mhz) */
+	{  1000000,  1000000,   950000,   950000,   950000},	/* L2(100Mhz) */
 #if (MALI_DVFS_STEPS > 1)
-	{  1100000,  1100000,  1000000,  1000000,   950000},	/* L0(266Mhz) */
+	{  1000000,  1000000,   950000,   950000,   950000},	/* L1(160Mhz) */
+#if (MALI_DVFS_STEPS > 2)
+	{  1100000,  1100000,  1000000,  1000000,   950000},	/* L0(267Mhz) */
+#endif
 #endif
 };
 #endif


### PR DESCRIPTION
https://github.com/CyanogenMod/android_kernel_samsung_smdk4210/blob/cm-10.1/drivers/media/video/samsung/mali/platform/orion-m400/mali_platform_dvfs.c#L77

Change-Id: I07c4dbd99d5adce880616162674f6ef2e4ece4fd
