### PR TITLE
neigh: Better handling of transition to NUD_PROBE state

### DIFF
--- a/net/core/neighbour.c
+++ b/net/core/neighbour.c
@@ -924,6 +924,7 @@ static void neigh_timer_handler(unsigned long arg)
 			neigh->nud_state = NUD_PROBE;
 			neigh->updated = jiffies;
 			atomic_set(&neigh->probes, 0);
+                        notify = 1;
 			next = now + neigh->parms->retrans_time;
 		}
 	} else {
@@ -1146,6 +1147,8 @@ int neigh_update(struct neighbour *neigh, const u8 *lladdr, u8 new,
 
 	if (new != old) {
 		neigh_del_timer(neigh);
+                if (new & NUD_PROBE)
+			atomic_set(&neigh->probes, 0);
 		if (new & NUD_IN_TIMER)
 			neigh_add_timer(neigh, (jiffies +
 						((new & NUD_REACHABLE) ?


### PR DESCRIPTION
[1] When entering NUD_PROBE state via neigh_update(), perhaps received
    from userspace, correctly (re)initialize the probes count to zero.

```
This is useful for forcing revalidation of a neighbor (for example
if the host is attempting to do DNA [IPv4 4436, IPv6 6059]).
```

[2] Notify listeners when a neighbor goes into NUD_PROBE state.

```
By sending notifications on entry to NUD_PROBE state listeners get
more timely warnings of imminent connectivity issues.

The current notifications on entry to NUD_STALE have somewhat
limited usefulness: NUD_STALE is a perfectly normal state, as is
NUD_DELAY, whereas notifications on entry to NUD_FAILURE come after
a neighbor reachability problem has been confirmed (typically after
three probes).
```

[Cherry-pick of upstream 765c9c639fbb132af0cafc6e1da22fe6cea26bb8]

Signed-off-by: Erik Kline ek@google.com
Acked-By: Lorenzo Colitti lorenzo@google.com
Acked-by: Hannes Frederic Sowa hannes@stressinduktion.org
Signed-off-by: David S. Miller davem@davemloft.net

Change-Id: I3a48f267a1bf752daeb3ff8a28de926ac66f5ad8
