### PR TITLE
timekeeping: fix 32-bit overflow in get_monotonic_boottime

### DIFF
--- a/kernel/time/timekeeping.c
+++ b/kernel/time/timekeeping.c
@@ -1059,7 +1059,7 @@ void get_monotonic_boottime(struct timespec *ts)
 	} while (read_seqretry(&xtime_lock, seq));
 
 	set_normalized_timespec(ts, ts->tv_sec + tomono.tv_sec + sleep.tv_sec,
-			ts->tv_nsec + tomono.tv_nsec + sleep.tv_nsec + nsecs);
+		(s64)ts->tv_nsec + tomono.tv_nsec + sleep.tv_nsec + nsecs);
 }
 EXPORT_SYMBOL_GPL(get_monotonic_boottime);
 


### PR DESCRIPTION
fixed upstream in v3.6 by ec145babe754f9ea1079034a108104b6001e001c

get_monotonic_boottime adds three nanonsecond values stored
in longs, followed by an s64.  If the long values are all
close to 1e9 the first three additions can overflow and
become negative when added to the s64.  Cast the first
value to s64 so that all additions are 64 bit.

Signed-off-by: Colin Cross ccross@android.com
[jstultz: Fished this out of the AOSP commong.git tree. This was
fixed upstream in v3.6 by ec145babe754f9ea1079034a108104b6001e001c]
Signed-off-by: John Stultz john.stultz@linaro.org
Signed-off-by: Greg Kroah-Hartman gregkh@linuxfoundation.org
Change-Id: If4ec90946bb49b022403c14e63903b3027dd5c58
