### PR TITLE
mfc5x: update from n7100 source drop

### DIFF
--- a/arch/arm/mach-exynos/include/mach/busfreq_exynos4.h
+++ b/arch/arm/mach-exynos/include/mach/busfreq_exynos4.h
@@ -27,6 +27,11 @@
 #define PRIME_DMC_MAX_THRESHOLD		30
 #define EXYNOS4412_DMC_MAX_THRESHOLD	30
 #define EXYNOS4212_DMC_MAX_THRESHOLD	30
+#if defined(CONFIG_MACH_P4NOTE) || defined(CONFIG_MACH_SP7160LTE) || defined(CONFIG_MACH_M0) || defined(CONFIG_MACH_C1) || defined(CONFIG_MACH_T0)
+#define DECODING_LOAD 5
+#else
+#define DECODING_LOAD 10
+#endif
 
 extern unsigned int up_threshold;
 extern unsigned int ppmu_threshold;

--- a/drivers/media/video/samsung/mfc5x/SsbSipMfcApi.h
+++ b/drivers/media/video/samsung/mfc5x/SsbSipMfcApi.h
@@ -41,7 +41,7 @@
 #define SAMSUNG_MFC_DEV_NAME           "/dev/s3c-mfc"
 
 #if defined(CONFIG_CPU_EXYNOS4212) || defined(CONFIG_CPU_EXYNOS4412)
-#define SUPPORT_SLICE_ENCODING        0 // originaly 1, but we're missing matching userspace
+#define SUPPORT_SLICE_ENCODING        0 // originally 1, but we're missing matching userspace
 #else
 #define SUPPORT_SLICE_ENCODING        0
 #endif
@@ -136,7 +136,7 @@ typedef enum {
     /* C210 specific feature */
     MFC_ENC_SETCONF_VUI_INFO,
     MFC_ENC_SETCONF_I_PERIOD,
-	MFC_ENC_SETCONF_SPS_PPS_GEN,
+    MFC_ENC_SETCONF_SPS_PPS_GEN,
     MFC_ENC_SETCONF_HIER_P,
 
     MFC_ENC_SETCONF_SEI_GEN,

--- a/drivers/media/video/samsung/mfc5x/mfc_buf.h
+++ b/drivers/media/video/samsung/mfc5x/mfc_buf.h
@@ -34,8 +34,13 @@
 #define ALIGN_H_L_L	16	/* Linear, Vertical, Luma		*/
 #define ALIGN_H_L_C	8	/* Linear, Vertical, Chroma		*/
 
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_GC1)
+/* System */					/* Size, Port, Align */
+#define MFC_FW_SYSTEM_SIZE	(0x100000)	/* 1MB, A, N(4KB for VMEM) */
+#else
 /* System */					/* Size, Port, Align */
 #define MFC_FW_SYSTEM_SIZE	(0x80000)	/* 512KB, A, N(4KB for VMEM) */
+#endif
 
 /* Instance */
 #define MFC_CTX_SIZE_L		(0x96000)	/* 600KB, N, 2KB, H.264 Decoding only */

--- a/drivers/media/video/samsung/mfc5x/mfc_cmd.c
+++ b/drivers/media/video/samsung/mfc5x/mfc_cmd.c
@@ -310,7 +310,7 @@ int mfc_cmd_inst_open(struct mfc_inst_ctx *ctx)
 	}
 
 	memset(&h2r_args, 0, sizeof(struct mfc_cmd_args));
-	h2r_args.arg[0] = ctx->codecid;
+	h2r_args.arg[0] = (1 << 29) | ctx->codecid;
 	h2r_args.arg[1] = crc << 31 | pixelcache;
 	h2r_args.arg[2] = ctx->ctxbufofs;
 	h2r_args.arg[3] = ctx->ctxbufsize;

--- a/drivers/media/video/samsung/mfc5x/mfc_dev.h
+++ b/drivers/media/video/samsung/mfc5x/mfc_dev.h
@@ -114,6 +114,10 @@ struct mfc_dev {
 #if defined(CONFIG_BUSFREQ)
 	atomic_t		busfreq_lock_cnt; /* Bus frequency Lock count */
 #endif
+#if defined(CONFIG_MACH_GC1) && defined(CONFIG_EXYNOS4_CPUFREQ)
+	atomic_t		cpufreq_lock_cnt; /* CPU frequency Lock count */
+	int				cpufreq_level; /* CPU frequency leve */
+#endif
 #if defined(CONFIG_CPU_EXYNOS4210) && defined(CONFIG_EXYNOS4_CPUFREQ)
 	atomic_t		cpufreq_lock_cnt; /* CPU frequency Lock count */
 	int				cpufreq_level; /* CPU frequency leve */

--- a/drivers/media/video/samsung/mfc5x/mfc_inst.c
+++ b/drivers/media/video/samsung/mfc5x/mfc_inst.c
@@ -55,6 +55,9 @@ struct mfc_inst_ctx *mfc_create_inst(void)
 #ifdef CONFIG_BUSFREQ
 	ctx->busfreq_flag = false;
 #endif
+#if defined(CONFIG_MACH_GC1) && defined(CONFIG_EXYNOS4_CPUFREQ)
+	ctx->cpufreq_flag = false;
+#endif
 #if defined(CONFIG_CPU_EXYNOS4210) && defined(CONFIG_EXYNOS4_CPUFREQ)
 	ctx->cpufreq_flag = false;
 #endif
@@ -193,34 +196,34 @@ int mfc_set_inst_cfg(struct mfc_inst_ctx *ctx, int type, void *arg)
 	}
 
 	switch (type) {
-		case MFC_DEC_SETCONF_POST_ENABLE:
-		case MFC_DEC_SETCONF_EXTRA_BUFFER_NUM:
-		case MFC_DEC_SETCONF_DISPLAY_DELAY:
-		case MFC_DEC_SETCONF_IS_LAST_FRAME:
-		case MFC_DEC_SETCONF_SLICE_ENABLE:
-		case MFC_DEC_SETCONF_CRC_ENABLE:
-		case MFC_DEC_SETCONF_FIMV1_WIDTH_HEIGHT:
-		case MFC_DEC_SETCONF_FRAME_TAG:
-		case MFC_DEC_SETCONF_IMMEDIATELY_DISPLAY:
-		case MFC_DEC_SETCONF_DPB_FLUSH:
-		case MFC_DEC_SETCONF_SEI_PARSE:
-		case MFC_DEC_SETCONF_PIXEL_CACHE:
-		case MFC_ENC_SETCONF_FRAME_TYPE:
-		case MFC_ENC_SETCONF_CHANGE_FRAME_RATE:
-		case MFC_ENC_SETCONF_CHANGE_BIT_RATE:
-		case MFC_ENC_SETCONF_FRAME_TAG:
-		case MFC_ENC_SETCONF_ALLOW_FRAME_SKIP:
-		case MFC_ENC_SETCONF_VUI_INFO:
-		case MFC_ENC_SETCONF_I_PERIOD:
-		case MFC_ENC_SETCONF_HIER_P:
-		case MFC_ENC_SETCONF_SEI_GEN:
-		case MFC_ENC_SETCONF_FRAME_PACKING:
-		case MFC_ENC_SETCONF_SPS_PPS_GEN:
-			if (ctx->c_ops->set_codec_cfg) {
-				if ((ctx->c_ops->set_codec_cfg(ctx, type, arg)) < 0)
-					return MFC_SET_CONF_FAIL;
-			}
-			break;
+	case MFC_DEC_SETCONF_POST_ENABLE:
+	case MFC_DEC_SETCONF_EXTRA_BUFFER_NUM:
+	case MFC_DEC_SETCONF_DISPLAY_DELAY:
+	case MFC_DEC_SETCONF_IS_LAST_FRAME:
+	case MFC_DEC_SETCONF_SLICE_ENABLE:
+	case MFC_DEC_SETCONF_CRC_ENABLE:
+	case MFC_DEC_SETCONF_FIMV1_WIDTH_HEIGHT:
+	case MFC_DEC_SETCONF_FRAME_TAG:
+	case MFC_DEC_SETCONF_IMMEDIATELY_DISPLAY:
+	case MFC_DEC_SETCONF_DPB_FLUSH:
+	case MFC_DEC_SETCONF_SEI_PARSE:
+	case MFC_DEC_SETCONF_PIXEL_CACHE:
+	case MFC_ENC_SETCONF_FRAME_TYPE:
+	case MFC_ENC_SETCONF_CHANGE_FRAME_RATE:
+	case MFC_ENC_SETCONF_CHANGE_BIT_RATE:
+	case MFC_ENC_SETCONF_FRAME_TAG:
+	case MFC_ENC_SETCONF_ALLOW_FRAME_SKIP:
+	case MFC_ENC_SETCONF_VUI_INFO:
+	case MFC_ENC_SETCONF_I_PERIOD:
+	case MFC_ENC_SETCONF_HIER_P:
+	case MFC_ENC_SETCONF_SEI_GEN:
+	case MFC_ENC_SETCONF_FRAME_PACKING:
+	case MFC_ENC_SETCONF_SPS_PPS_GEN:
+		if (ctx->c_ops->set_codec_cfg) {
+			if ((ctx->c_ops->set_codec_cfg(ctx, type, arg)) < 0)
+				return MFC_SET_CONF_FAIL;
+		}
+		break;
 
 		default:
 			mfc_err("invalid set config type: 0x%08x\n", type);

--- a/drivers/media/video/samsung/mfc5x/mfc_inst.h
+++ b/drivers/media/video/samsung/mfc5x/mfc_inst.h
@@ -158,6 +158,10 @@ struct mfc_inst_ctx {
 	int busfreq_flag;		/* context bus frequency flag */
 #endif
 
+#if defined(CONFIG_MACH_GC1) && defined(CONFIG_EXYNOS4_CPUFREQ)
+	int cpufreq_flag; /* context CPU frequency flag*/
+#endif
+
 #if defined(CONFIG_CPU_EXYNOS4210) && defined(CONFIG_EXYNOS4_CPUFREQ)
 	int cpufreq_flag; /* context CPU frequency flag*/
 #endif

--- a/drivers/media/video/samsung/mfc5x/mfc_mem.c
+++ b/drivers/media/video/samsung/mfc5x/mfc_mem.c
@@ -551,12 +551,26 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 	/* early allocator */
 #if defined(CONFIG_S5P_MEM_CMA)
 #ifdef  CONFIG_EXYNOS_CONTENT_PATH_PROTECTION
-#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_M0)
+#ifdef CONFIG_USE_MFC_CMA
+#if defined(CONFIG_MACH_M0)
 	cma_infos[0].lower_bound = 0x5C100000;
 	cma_infos[0].upper_bound = 0x5F200000;
 	cma_infos[0].total_size  = 0x03100000;
 	cma_infos[0].free_size   = 0x03100000;
 	cma_infos[0].count   = 1;
+#elif defined(CONFIG_MACH_GC1) || defined(CONFIG_MACH_GC2PD)
+	cma_infos[0].lower_bound = 0x50200000;
+	cma_infos[0].upper_bound = 0x53300000;
+	cma_infos[0].total_size  = 0x03100000;
+	cma_infos[0].free_size   = 0x03100000;
+	cma_infos[0].count   = 1;
+#elif defined(CONFIG_MACH_TAB3) || defined(CONFIG_MACH_ZEST)
+	cma_infos[0].lower_bound = 0x58100000;
+	cma_infos[0].upper_bound = 0x5B200000;
+	cma_infos[0].total_size  = 0x03100000;
+	cma_infos[0].free_size	 = 0x03100000;
+	cma_infos[0].count   = 1;
+#endif
 #else
 	if (cma_info(&cma_infos[0], dev->device, "A")) {
 		mfc_info("failed to get CMA info of 'mfc-secure'\n");
@@ -611,8 +625,14 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 		return -ENOMEM;
 	}
 
-#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_M0)
+#ifdef CONFIG_USE_MFC_CMA
+#if defined(CONFIG_MACH_GC1) || defined(CONFIG_MACH_GC2PD)
+	base[0] = 0x50200000;
+#elif defined(CONFIG_MACH_TAB3) || defined(CONFIG_MACH_ZEST)
+	base[0] = 0x58100000;
+#else
 	base[0] = 0x5c100000;
+#endif
 	dev->mem_infos[0].base = base[0];
 	dev->mem_infos[0].size = size;
 	dev->mem_infos[0].addr = phys_to_virt(base[0]);
@@ -707,6 +727,20 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 		dev->mem_infos[0].size = size;
 		dev->mem_infos[0].addr = cma_get_virt(base[0], size, 0);
 	} else if (dev->mem_ports == 2) {
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_Q1_BD)
+		/* for MFC0:A */
+		cma_infos[0].lower_bound = 0x67200000;
+		cma_infos[0].upper_bound = 0x68400000;
+		cma_infos[0].total_size  = 0x01200000;
+		cma_infos[0].free_size   = 0x01200000;
+		cma_infos[0].count   = 1;
+		/* for MFC1:B */
+		cma_infos[1].lower_bound = 0x68400000;
+		cma_infos[1].upper_bound = 0x6A000000;
+		cma_infos[1].total_size  = 0x01C00000;
+		cma_infos[1].free_size   = 0x01C00000;
+		cma_infos[1].count   = 1;
+#else
 		if (cma_info(&cma_infos[0], dev->device, "A")) {
 			mfc_info("failed to get CMA info of 'mfc0'\n");
 			return -ENOMEM;
@@ -716,7 +750,7 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 			mfc_info("failed to get CMA info of 'mfc1'\n");
 			return -ENOMEM;
 		}
-
+#endif
 		if (cma_infos[0].lower_bound > cma_infos[1].lower_bound)
 			cma_index = 1;
 
@@ -733,7 +767,11 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 		base[0] = cma_alloc(dev->device, cma_index ? "B" : "A",
 			MFC_FW_SYSTEM_SIZE, ALIGN_128KB);
 #else
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_Q1_BD)
+		base[0] = cma_index ? 0x68400000 : 0x67200000;
+#else
 		base[0] = cma_alloc(dev->device, cma_index ? "B" : "A", size, ALIGN_128KB);
+#endif
 #endif
 		if (IS_ERR_VALUE(base[0])) {
 			mfc_err("failed to get rsv. memory from CMA on port #0");
@@ -742,7 +780,11 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 
 		dev->mem_infos[0].base = base[0];
 		dev->mem_infos[0].size = size;
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_Q1_BD)
+		dev->mem_infos[0].addr = phys_to_virt(base[0]);
+#else
 		dev->mem_infos[0].addr = cma_get_virt(base[0], size, 0);
+#endif
 
 		/* swap CMA index */
 		cma_index = !cma_index;
@@ -760,7 +802,11 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 		base[1] = cma_index ? cma_infos[1].lower_bound :
 			cma_infos[0].lower_bound;
 #else
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_Q1_BD)
+		base[1] = cma_index ? 0x68400000 : 0x67200000;
+#else
 		base[1] = cma_alloc(dev->device, cma_index ? "B" : "A", size, ALIGN_128KB);
+#endif
 #endif
 		if (IS_ERR_VALUE(base[1])) {
 			mfc_err("failed to get rsv. memory from CMA on port #1");
@@ -770,7 +816,11 @@ int mfc_init_mem_mgr(struct mfc_dev *dev)
 
 		dev->mem_infos[1].base = base[1];
 		dev->mem_infos[1].size = size;
+#if defined(CONFIG_USE_MFC_CMA) && defined(CONFIG_MACH_Q1_BD)
+		dev->mem_infos[1].addr = phys_to_virt(base[1]);
+#else
 		dev->mem_infos[1].addr = cma_get_virt(base[1], size, 0);
+#endif
 	} else {
 		mfc_err("failed to get reserved memory from CMA");
 		return -EPERM;


### PR DESCRIPTION
- include a few fixes for weird samsung mistakes in mfc_open

Change-Id: Icad82feac58c07f6af4c014e7dc967c70c6d1405
